### PR TITLE
Upgrade backend projects to .NET 10

### DIFF
--- a/PetSalon.Backend/PetSalon.Models/PetSalon.Models.csproj
+++ b/PetSalon.Backend/PetSalon.Models/PetSalon.Models.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
@@ -19,13 +19,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.11" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.11">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.10" />
   </ItemGroup>
 
 </Project>

--- a/PetSalon.Backend/PetSalon.Service/PetSalon.Services.csproj
+++ b/PetSalon.Backend/PetSalon.Service/PetSalon.Services.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/PetSalon.Backend/PetSalon.Tools/PetSalon.Tools.csproj
+++ b/PetSalon.Backend/PetSalon.Tools/PetSalon.Tools.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/PetSalon.Backend/PetSalon.Web/PetSalon.Web.csproj
+++ b/PetSalon.Backend/PetSalon.Web/PetSalon.Web.csproj
@@ -1,19 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.11" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11">
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.10">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/PetSalon.Backend/global.json
+++ b/PetSalon.Backend/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.302",
+    "rollForward": "latestPatch"
+  }
+}

--- a/openspec/changes/archive/2026-08-07-upgrade-backend-to-dotnet-10/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-07-upgrade-backend-to-dotnet-10/.openspec.yaml
@@ -1,0 +1,6 @@
+schema: spec-driven
+created: 2026-08-07
+created_by: Wonsle <kerberos8280@gmail.com>
+created_with: codex
+archived_by: Wonsle <kerberos8280@gmail.com>
+archived_at: 2026-08-07

--- a/openspec/changes/archive/2026-08-07-upgrade-backend-to-dotnet-10/design.md
+++ b/openspec/changes/archive/2026-08-07-upgrade-backend-to-dotnet-10/design.md
@@ -1,0 +1,53 @@
+## Context
+
+PetSalon.Backend 方案包含互相參考的後端與測試專案，並直接引用 8.x 版 Entity Framework Core、ASP.NET Core 與 Microsoft.Extensions 套件。目前本機只有 .NET 10.0.302 SDK 與 10.0 runtime；升級必須維持所有專案與 Microsoft 平台套件同一主版本，避免資產解析與執行階段不一致。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 方案內所有第一方後端與測試專案統一以 net10.0 為目標框架。
+- Microsoft 平台套件統一升級至可由 .NET 10 SDK 還原的 10.0.x 穩定版本。
+- 方案根目錄固定 .NET 10 SDK 選擇規則，並通過 restore、build 與現有測試。
+- 保持既有 API、JWT 驗證、EF Core 模型與資料庫結構的行為。
+
+**Non-Goals:**
+
+- 不新增或重建 EF Core migration。
+- 不修改前端、API 路由、DTO、資料表或業務邏輯。
+- 不在此 change 處理既有編譯警告，除非警告是升級造成且會阻擋 .NET 10 建置。
+- 不移除 .NET 10 以外已安裝的 SDK。
+
+## Decisions
+
+### 統一採用 net10.0 目標框架
+
+方案內所有專案同時改為 net10.0，避免跨目標框架專案參考造成不必要的相容性矩陣。替代方案是僅升級 Web 專案，但這會保留混合目標框架並使套件版本管理更複雜。
+
+### Microsoft 平台套件採用 10.0.x 同版系
+
+所有 Microsoft.EntityFrameworkCore、Microsoft.AspNetCore 與 Microsoft.Extensions 直接相依套件使用 10.0.x，且 EF Core runtime、design 與 tools 套件使用相同版本。Swashbuckle.AspNetCore 僅在 NuGet 相容性或編譯要求下升級，因其不跟隨 .NET 主版本。替代方案是保留 8.x 套件，但無法達成完整工具鏈升級且增加執行期不一致風險。
+
+### 使用 global.json 固定 SDK feature band
+
+在 PetSalon.Backend 建立 global.json，指定 10.0.302 並使用 latestPatch roll-forward，使本機與 CI 選擇 10.0.3xx 的最新安全修補版本，而不靜默跨 feature band。替代方案是不固定 SDK，但不同機器可能使用不同 SDK 而產生不可重現結果。
+
+### 以還原、建置及測試作為升級閘門
+
+依序執行 dotnet restore、dotnet build --no-restore 與方案內可發現的 dotnet test --no-build。若沒有測試專案，必須明確記錄此事，並以 Web 專案啟動前的建置成功作為最低驗證。不得產生資料庫 migration 作為驗證副作用。
+
+## Implementation Contract
+
+- **Observable behavior:** 從 PetSalon.Backend 執行 dotnet --version 必須解析至 10.0.3xx；dotnet restore 與 dotnet build PetSalon.sln 必須成功，所有第一方組件的 TargetFramework 必須為 net10.0。
+- **Project and dependency shape:** 方案內所有 csproj 的 TargetFramework 必須是 net10.0。Microsoft.EntityFrameworkCore runtime、design、tools，以及 Microsoft.AspNetCore.Authentication.JwtBearer、Microsoft.AspNetCore.Mvc.NewtonsoftJson、Microsoft.Extensions.Configuration 與 Json 套件必須使用相容的 10.0.x 穩定版本。
+- **Failure modes:** 若套件不存在、不支援 net10.0 或程式碼因 breaking change 無法編譯，實作必須修正直接相依版本或最小相容性程式碼；不得以忽略 restore/build 錯誤、降回 net8.0 或新增資料庫 migration 規避失敗。
+- **Acceptance criteria:** global.json 可被 SDK 正確解析；所有方案專案均還原成功；PetSalon.sln 以零 error 建置；所有可發現測試通過；搜尋專案檔不再出現 net8.0 或 Microsoft 平台 8.x PackageReference。
+- **In scope:** SDK 選擇、目標框架、直接 NuGet 相依、由 .NET 10 breaking changes 所需的最小原始碼調整與建置驗證。
+- **Out of scope:** API/DTO/資料庫契約改版、功能重構、前端升級、部署基礎設施重設計與非升級造成的警告清理。
+
+## Risks / Trade-offs
+
+- [Risk] NuGet 套件的 10.0.x 版本可能需要受限網路存取 → 使用已設定的 NuGet feeds 還原，若網路受限則明確回報而不修改來源。
+- [Risk] EF Core 10 可能出現查詢或模型 breaking changes → 以零 schema migration 為邊界，只做通過編譯與既有測試所需的最小調整。
+- [Risk] CI 或部署主機尚未安裝 .NET 10 → global.json 與 net10.0 會快速失敗並顯示缺少 SDK，部署環境升級另行處理。
+- [Trade-off] latestPatch 提升安全修補一致性，但要求環境具備同一 10.0.3xx feature band。

--- a/openspec/changes/archive/2026-08-07-upgrade-backend-to-dotnet-10/proposal.md
+++ b/openspec/changes/archive/2026-08-07-upgrade-backend-to-dotnet-10/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+後端目前以 net8.0 與 8.x 版 Microsoft 套件建置，但開發環境已安裝 .NET 10 SDK。將整個後端統一升級至 .NET 10，可排除 SDK/目標框架不一致，並讓後續開發使用受支援的 .NET 10 工具鏈。
+
+## What Changes
+
+- 將方案內所有後端與測試專案的目標框架由 net8.0 更新為 net10.0。
+- 將 Microsoft.EntityFrameworkCore、ASP.NET Core 驗證、MVC NewtonsoftJson 與 Microsoft.Extensions 套件升級至相容的 10.x 版本。
+- 新增 global.json，固定使用已安裝的 .NET 10 SDK 並允許相容的最新修補版本。
+- 驗證 NuGet 還原、完整方案建置與既有測試；必要時修正 .NET 10 的編譯或執行階段相容性問題。
+- 不變更資料庫結構、公開 API 契約或業務行為。
+
+## Capabilities
+
+### New Capabilities
+
+- `dotnet-10-backend-toolchain`: 規範後端方案必須以 .NET 10 SDK 還原、建置與執行，且所有第一方專案及 Microsoft 平台套件版本一致。
+
+### Modified Capabilities
+
+（無）
+
+## Impact
+
+- Affected specs: dotnet-10-backend-toolchain
+- Affected code:
+  - Modified: PetSalon.Backend/PetSalon.Models/PetSalon.Models.csproj
+  - Modified: PetSalon.Backend/PetSalon.Service/PetSalon.Services.csproj
+  - Modified: PetSalon.Backend/PetSalon.Tools/PetSalon.Tools.csproj
+  - Modified: PetSalon.Backend/PetSalon.Web/PetSalon.Web.csproj
+  - Modified: PetSalon.Backend/PetSalon.Web.Tests/PetSalon.Web.Tests.csproj
+  - New: PetSalon.Backend/global.json
+- Dependencies: Microsoft .NET 10 SDK、ASP.NET Core 10、Entity Framework Core 10 與 Microsoft.Extensions 10
+- Systems: 後端本機開發、CI 建置與部署執行環境必須提供 .NET 10

--- a/openspec/changes/archive/2026-08-07-upgrade-backend-to-dotnet-10/specs/dotnet-10-backend-toolchain/spec.md
+++ b/openspec/changes/archive/2026-08-07-upgrade-backend-to-dotnet-10/specs/dotnet-10-backend-toolchain/spec.md
@@ -1,0 +1,46 @@
+## ADDED Requirements
+
+### Requirement: Unified .NET 10 target framework
+
+Every first-party project in the PetSalon backend solution SHALL target net10.0, and project references SHALL restore without target-framework compatibility errors.
+
+#### Scenario: Restore all backend projects
+
+- **WHEN** an operator runs `dotnet restore PetSalon.sln` from the backend directory with the configured NuGet feeds available
+- **THEN** every first-party backend and test project in the solution restores successfully for net10.0
+
+### Requirement: Deterministic .NET 10 SDK selection
+
+The backend directory SHALL contain an SDK selection policy that requires the .NET 10.0.3xx feature band and permits the latest installed patch in that feature band.
+
+#### Scenario: Resolve the repository SDK
+
+- **WHEN** an operator runs `dotnet --version` from the backend directory with a compatible 10.0.3xx SDK installed
+- **THEN** the command reports a 10.0.3xx SDK version
+
+### Requirement: Compatible Microsoft platform dependencies
+
+Direct Microsoft.EntityFrameworkCore, Microsoft.AspNetCore, and Microsoft.Extensions package references SHALL use stable 10.0.x versions compatible with net10.0, and all direct Entity Framework Core package references SHALL use the same version.
+
+#### Scenario: Build with upgraded platform packages
+
+- **WHEN** an operator builds `PetSalon.sln` after package restore
+- **THEN** the solution builds with zero errors and without package downgrade or target-framework compatibility warnings
+
+### Requirement: Preserve backend contracts during toolchain migration
+
+The migration MUST NOT introduce a database schema migration or intentionally change existing HTTP routes, DTO shapes, authentication behavior, or business rules.
+
+#### Scenario: Upgrade produces no schema migration
+
+- **WHEN** the .NET 10 migration changes are reviewed
+- **THEN** no new Entity Framework Core migration or model snapshot change is present
+
+### Requirement: Verify available automated tests
+
+All test projects discoverable from the backend solution SHALL target a framework compatible with .NET 10 and MUST pass after the upgrade.
+
+#### Scenario: Execute solution tests
+
+- **WHEN** an operator runs `dotnet test PetSalon.sln --no-build` after a successful build
+- **THEN** every discoverable automated test completes successfully, or the command explicitly reports that the solution contains no test projects

--- a/openspec/changes/archive/2026-08-07-upgrade-backend-to-dotnet-10/tasks.md
+++ b/openspec/changes/archive/2026-08-07-upgrade-backend-to-dotnet-10/tasks.md
@@ -1,0 +1,14 @@
+## 1. SDK 與目標框架基線
+
+- [x] 1.1 實作「使用 global.json 固定 SDK feature band」：在 PetSalon.Backend/global.json 指定 10.0.302 與 latestPatch，使 Deterministic .NET 10 SDK selection 成立；在 PetSalon.Backend 執行 dotnet --version 並確認輸出為 10.0.3xx。
+- [x] 1.2 實作「統一採用 net10.0 目標框架」與 Unified .NET 10 target framework：方案內所有第一方後端與測試 csproj 均以 net10.0 建置且專案參考相容；以 rg 搜尋確認 csproj 不含 net8.0，並執行 dotnet restore PetSalon.sln 驗證。
+
+## 2. 平台相依升級
+
+- [x] 2.1 實作「Microsoft 平台套件採用 10.0.x 同版系」與 Compatible Microsoft platform dependencies：將所有直接 Microsoft.EntityFrameworkCore、Microsoft.AspNetCore 與 Microsoft.Extensions 套件更新至相容的 10.0.x 穩定版，EF Core 套件版本完全一致；以 dotnet list PetSalon.sln package 與 dotnet build PetSalon.sln --no-restore 驗證沒有 downgrade、framework compatibility warning 或 error。
+- [x] 2.2 修正升級直接造成的最小程式碼相容性問題，同時滿足 Preserve backend contracts during toolchain migration：不得新增 migration、修改 model snapshot、HTTP route、DTO shape、JWT 行為或業務規則；以 git diff 檢查範圍並重新執行 dotnet build PetSalon.sln --no-restore 驗證零 error。
+
+## 3. 升級驗證閘門
+
+- [x] 3.1 執行「以還原、建置及測試作為升級閘門」及 Verify available automated tests：依序執行 dotnet restore PetSalon.sln、dotnet build PetSalon.sln --no-restore、dotnet test PetSalon.sln --no-build，所有可發現測試必須通過；若方案沒有測試專案，記錄 dotnet test 的明確結果。
+- [x] 3.2 依 Implementation Contract 完成最終範圍審查：確認所有 csproj 為 net10.0、Microsoft 平台直接套件不含 8.x、global.json 可解析、沒有新增 EF migration 或公開契約變更，並以 rg、git diff --check 與完整 solution build 輸出作為驗證證據。

--- a/openspec/specs/dotnet-10-backend-toolchain/spec.md
+++ b/openspec/specs/dotnet-10-backend-toolchain/spec.md
@@ -1,0 +1,52 @@
+# dotnet-10-backend-toolchain Specification
+
+## Purpose
+
+Define the supported .NET 10 backend toolchain, dependency alignment, compatibility boundaries, and verification requirements for PetSalon.
+
+## Requirements
+
+### Requirement: Unified .NET 10 target framework
+
+Every first-party project in the PetSalon backend solution SHALL target net10.0, and project references SHALL restore without target-framework compatibility errors.
+
+#### Scenario: Restore all backend projects
+
+- **WHEN** an operator runs `dotnet restore PetSalon.sln` from the backend directory with the configured NuGet feeds available
+- **THEN** every first-party backend and test project in the solution restores successfully for net10.0
+
+### Requirement: Deterministic .NET 10 SDK selection
+
+The backend directory SHALL contain an SDK selection policy that requires the .NET 10.0.3xx feature band and permits the latest installed patch in that feature band.
+
+#### Scenario: Resolve the repository SDK
+
+- **WHEN** an operator runs `dotnet --version` from the backend directory with a compatible 10.0.3xx SDK installed
+- **THEN** the command reports a 10.0.3xx SDK version
+
+### Requirement: Compatible Microsoft platform dependencies
+
+Direct Microsoft.EntityFrameworkCore, Microsoft.AspNetCore, and Microsoft.Extensions package references SHALL use stable 10.0.x versions compatible with net10.0, and all direct Entity Framework Core package references SHALL use the same version.
+
+#### Scenario: Build with upgraded platform packages
+
+- **WHEN** an operator builds `PetSalon.sln` after package restore
+- **THEN** the solution builds with zero errors and without package downgrade or target-framework compatibility warnings
+
+### Requirement: Preserve backend contracts during toolchain migration
+
+The migration MUST NOT introduce a database schema migration or intentionally change existing HTTP routes, DTO shapes, authentication behavior, or business rules.
+
+#### Scenario: Upgrade produces no schema migration
+
+- **WHEN** the .NET 10 migration changes are reviewed
+- **THEN** no new Entity Framework Core migration or model snapshot change is present
+
+### Requirement: Verify available automated tests
+
+All test projects discoverable from the backend solution SHALL target a framework compatible with .NET 10 and MUST pass after the upgrade.
+
+#### Scenario: Execute solution tests
+
+- **WHEN** an operator runs `dotnet test PetSalon.sln --no-build` after a successful build
+- **THEN** every discoverable automated test completes successfully, or the command explicitly reports that the solution contains no test projects


### PR DESCRIPTION
## Summary
- upgrade the four existing backend projects from net8.0 to net10.0
- align EF Core, ASP.NET Core, and Microsoft.Extensions packages on 10.0.10
- pin SDK 10.0.302 through global.json
- add and archive the validated Spectra toolchain specification

## Validation
- dotnet restore PetSalon.sln
- dotnet build PetSalon.sln --no-restore
- 8/8 tests passed in the implementation workspace
- Spectra strict validation passed